### PR TITLE
allow for customization of PAR payloads

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -214,21 +214,41 @@ func (c *Client) AuthServerDpopJwt(method, url, nonce string, privateJwk jwk.Key
 	return tokenString, nil
 }
 
-func (c *Client) SendParAuthRequest(ctx context.Context, authServerUrl string, authServerMeta *OauthAuthorizationMetadata, loginHint, scope string, dpopPrivateKey jwk.Key) (*SendParAuthResponse, error) {
+type ParAuthRequestOpts struct {
+	State        string
+	PKCEVerifier string
+}
+
+func (c *Client) SendParAuthRequest(ctx context.Context, authServerUrl string, authServerMeta *OauthAuthorizationMetadata, loginHint, scope string, dpopPrivateKey jwk.Key, opts ...ParAuthRequestOpts) (*SendParAuthResponse, error) {
 	if authServerMeta == nil {
 		return nil, fmt.Errorf("nil metadata provided")
+	}
+	var opt ParAuthRequestOpts
+	if len(opts) > 0 {
+		opt = opts[0]
 	}
 
 	parUrl := authServerMeta.PushedAuthorizationRequestEndpoint
 
-	state, err := internal_helpers.GenerateToken(10)
-	if err != nil {
-		return nil, fmt.Errorf("could not generate state token: %w", err)
+	var state string
+	var err error
+	if opt.State != "" {
+		state = opt.State
+	} else {
+		state, err = internal_helpers.GenerateToken(10)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate state token: %w", err)
+		}
 	}
 
-	pkceVerifier, err := internal_helpers.GenerateToken(48)
-	if err != nil {
-		return nil, fmt.Errorf("could not generate pkce verifier: %w", err)
+	var pkceVerifier string
+	if opt.PKCEVerifier != "" {
+		pkceVerifier = opt.PKCEVerifier
+	} else {
+		pkceVerifier, err = internal_helpers.GenerateToken(48)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate pkce verifier: %w", err)
+		}
 	}
 
 	codeChallenge := internal_helpers.GenerateCodeChallenge(pkceVerifier)


### PR DESCRIPTION
So I'm working on a library/microservice that will act as a transparent proxy between `@atproto/oauth-client` stuff and PDSses. The goal is to enable developers to upgrade to long-lived confidental OAuth client sessions without requiring them to reinvent their browser clients and authentication sessions. Just point the client at this service, it talks to the PDS on the backend, and you can keep using the same front-end code. Kinda neat! [The work-in-progress is here](https://github.com/streamplace/streamplace/pull/157).

In the interest of making this easy to integrate, I'm doing something kinda hacky and kinda clever with the OAuth sessions: rather than separate storage with separate indexing for the PAR requests and OAuth sessions, I just have a single table which uses the `jkt` of the DPoP key as the primary key for the whole thing. This means I can provide users of my library with a really easy-to-implement interface:

```
	createOAuthSession func(id string, session *OAuthSession) error
	updateOAuthSession func(id string, session *OAuthSession) error
	getOAuthSession   func(id string) (*OAuthSession, error)
```

To make that happen I'm doing some hacks with the (downstream, client-side) PAR — the `jkt` gets encoded into the `request_uri` field so I can look it up when executing the PAR. I think it's still secure – there's a UUID appended to the field, it's still random — it just lets me look up the jkt later. And that brings me to this PR — I also need to encode it in the `state` field that goes upstream to the PDS so I can match it back up with the session without requiring my users to implement a `getOAuthSessionByState` object or something like that. So this lets you customize the state field. I added it as a variadic parameter at the end of the function to not break API compatibility but I could totally do it with a separate function or something if that'd be cleaner.

I also added the option to customize the `PKCEVerifier`. I don't have a use case for that, it just seemed weird to allow customization of one but not both.

Possibly a better way to do this! Just the least-bad way I could come up with at the end of a long stream.